### PR TITLE
Provide a default for the token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,7 @@ description: 'Create a comment for a commit on GitHub'
 inputs:
   token:
     description: 'The GitHub authentication token'
+    default: ${{ github.token }}
     required: true
   sha:
     description: 'The commit SHA. Defaults to the current commit.'


### PR DESCRIPTION
Stolen from https://github.com/ouzi-dev/commit-status-updater/blob/master/action.yml#L11

(I haven't actually verified that this works, I just noticed that most other similar actions defaults to the provided token and thought that it was strange to require one)