### PR TITLE
feat: add eval to get env vars working

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -400,7 +400,7 @@ async function run() {
         headers: {
           authorization: `token ${inputs.token}`
         },
-        body: `${inputs.body}`,
+        body: eval('`'+inputs.body+'`'),
         path: `${inputs.path}`,
         position: `${inputs.position}`
       }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ async function run() {
         headers: {
           authorization: `token ${inputs.token}`
         },
-        body: `${inputs.body}`,
+        body: eval('`'+inputs.body+'`'),
         path: `${inputs.path}`,
         position: `${inputs.position}`
       }


### PR DESCRIPTION
Not sure the reason the `eval` part was deleted, but the _evaluation of environment variables_ stopped working when that was removed.

This PR adds it back again.
